### PR TITLE
Fix Kaily/Copilot widget (CSP) and update Kaily client list

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,14 +7,18 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
     <!-- Security headers -->
+    <!-- CSP allows the Kaily/Copilot chat widget (script.copilot.live loader + its
+         api/cdn/platform/public subdomains, kaily.ai, fonts, and voice/video media). -->
     <meta http-equiv="Content-Security-Policy"
       content="default-src 'self';
-               script-src 'self' 'unsafe-inline' https://*.copilot.live;
-               style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-               font-src 'self' https://fonts.gstatic.com;
-               img-src 'self' data: https:;
-               connect-src 'self' https://*.copilot.live wss://*.copilot.live;
-               frame-src https://*.copilot.live;
+               script-src 'self' 'unsafe-inline' https://*.copilot.live https://*.kaily.ai;
+               style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.copilot.live https://*.kaily.ai;
+               font-src 'self' data: https://fonts.gstatic.com https://*.copilot.live https://*.kaily.ai;
+               img-src 'self' data: blob: https:;
+               media-src 'self' blob: https://*.copilot.live https://*.kaily.ai;
+               worker-src 'self' blob:;
+               connect-src 'self' https://*.copilot.live wss://*.copilot.live https://*.kaily.ai wss://*.kaily.ai https://fonts.googleapis.com;
+               frame-src https://*.copilot.live https://*.kaily.ai;
                frame-ancestors 'none';">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -7,8 +7,9 @@
     "clients": [
       "JioMart",
       "Ajio",
+      "Reliance Digital",
+      "Metro Wholesale",
       "Being Human",
-      "Pantaloons",
       "Guess"
     ],
     "responsibilities": [


### PR DESCRIPTION
## Summary

**1. Chat widget fix (CSP)** — The Kaily/Copilot bot wasn't loading because the CSP added in the security pass only whitelisted `copilot.live` for `script`/`connect`/`frame`. The widget actually loads stylesheets, fonts, media, and websockets from several `copilot.live` subdomains (`api`, `cdn`, `platform`, `public`) and `kaily.ai`. Widened the CSP to allow:
- `script/style/font/frame`: `*.copilot.live` + `*.kaily.ai`
- `media` + `worker`: `blob:` (for voice/video) + the widget domains
- `connect`: `*.copilot.live`, `*.kaily.ai`, their `wss://`, and the Google Fonts CSS endpoint

The public widget token (`cat-6r8kty8r`) is confirmed present in the build and unchanged.

**2. Kaily client list** — Removed **Pantaloons**; added **Reliance Digital** and **Metro Wholesale**. Final list: JioMart, Ajio, Reliance Digital, Metro Wholesale, Being Human, Guess.

## Test plan
- [ ] Chat widget appears (bottom-right) on https://rajjadon.github.io
- [ ] No CSP violation errors in browser console
- [ ] Kaily.ai card shows the updated client chips (no Pantaloons; Reliance Digital + Metro Wholesale present)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfGjc4Z3Nq7adDWNBXA47r)_