### PR TITLE
UI fixes: glass cards, rebalanced hero, Kaily.ai title, footer, About heading

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -24,11 +24,14 @@ const About = () => (
     <Box id="about" sx={{ mb: { xs: 8, md: 12 } }}>
       <Typography
         variant="overline"
-        sx={{ color: "secondary.main", fontWeight: 700, letterSpacing: "0.15em" }}
+        sx={{ color: "secondary.main", fontWeight: 700, letterSpacing: "0.15em", display: "block" }}
       >
         ABOUT ME
       </Typography>
-      <Typography variant="h4" sx={{ mb: 4, mt: 0.5 }}>
+      <Typography
+        variant="h4"
+        sx={{ mb: 4, mt: 0.5, fontSize: { xs: "1.6rem", sm: "2rem" }, lineHeight: 1.2 }}
+      >
         A bit about who I am
       </Typography>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -53,7 +53,7 @@ const Footer = () => (
       <Divider sx={{ my: 2.5 }} />
 
       <Typography variant="caption" color="text.secondary" sx={{ display: "block", textAlign: "center" }}>
-        © {new Date().getFullYear()} {profile.name.split(" ")[0]} · Built with React &amp; Material UI
+        © {new Date().getFullYear()} {profile.name}
       </Typography>
     </Container>
   </Box>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -64,14 +64,14 @@ const Profile = () => {
             display: "flex",
             flexDirection: { xs: "column-reverse", md: "row" },
             alignItems: "center",
-            justifyContent: "space-between",
-            gap: { xs: 4, md: 6 },
+            justifyContent: "center",
+            gap: { xs: 4, md: 9 },
             py: { xs: 3, md: 5 },
-            minHeight: { md: "78vh" },
+            minHeight: { md: "80vh" },
           }}
         >
           {/* Text side */}
-          <Box sx={{ flex: 1, textAlign: { xs: "center", md: "left" } }}>
+          <Box sx={{ flexShrink: 1, maxWidth: 560, textAlign: { xs: "center", md: "left" } }}>
             <Chip
               label="● Open to opportunities"
               size="small"
@@ -220,18 +220,33 @@ const Profile = () => {
           </Box>
 
           {/* Avatar side */}
-          <Box sx={{ flexShrink: 0, position: "relative" }}>
+          <Box sx={{ flexShrink: 0, position: "relative", display: "grid", placeItems: "center" }}>
+            {/* Decorative dotted ring */}
+            <Box
+              aria-hidden
+              component={motion.div}
+              animate={{ rotate: 360 }}
+              transition={{ duration: 40, repeat: Infinity, ease: "linear" }}
+              sx={{
+                position: "absolute",
+                width: { xs: 230, md: 320 },
+                height: { xs: 230, md: 320 },
+                borderRadius: "50%",
+                border: "1px dashed rgba(148,163,184,0.25)",
+                pointerEvents: "none",
+              }}
+            />
             <Box
               component={motion.div}
               animate={{ scale: [1, 1.04, 1] }}
               transition={{ duration: 6, repeat: Infinity, ease: "easeInOut" }}
               sx={{
-                width: { xs: 170, md: 230 },
-                height: { xs: 170, md: 230 },
+                width: { xs: 190, md: 270 },
+                height: { xs: 190, md: 270 },
                 borderRadius: "50%",
                 p: "4px",
                 background: "linear-gradient(135deg, #6366f1, #22d3ee)",
-                boxShadow: "0 0 60px rgba(99,102,241,0.4)",
+                boxShadow: "0 0 80px rgba(99,102,241,0.45)",
               }}
             >
               <Avatar

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -82,28 +82,33 @@ const FeaturedCard = ({ project }: { project: Project }) => {
           }}
         />
         <Box sx={{ position: "relative" }}>
-          <Chip
-            label="★ Flagship Product"
-            size="small"
-            sx={{
-              mb: 1.5,
-              bgcolor: "rgba(34,211,238,0.15)",
-              color: "#22d3ee",
-              border: "1px solid rgba(34,211,238,0.4)",
-              fontWeight: 700,
-              fontSize: "0.68rem",
-            }}
-          />
+          <Box sx={{ mb: 1.5 }}>
+            <Chip
+              label="★ Flagship Product"
+              size="small"
+              sx={{
+                bgcolor: "rgba(34,211,238,0.15)",
+                color: "#22d3ee",
+                border: "1px solid rgba(34,211,238,0.4)",
+                fontWeight: 700,
+                fontSize: "0.68rem",
+              }}
+            />
+          </Box>
           <Typography
-            variant="h4"
+            variant="h3"
             component={url ? Link : "h3"}
             href={url ?? undefined}
             target={url ? "_blank" : undefined}
             rel={url ? "noopener noreferrer" : undefined}
             sx={{
-              display: "inline-block",
+              display: "block",
               fontWeight: 800,
+              fontSize: { xs: "2rem", md: "2.6rem" },
+              lineHeight: 1.25,
+              pb: "0.12em",
               textDecoration: "none",
+              width: "fit-content",
               background: "linear-gradient(135deg, #6366f1, #22d3ee)",
               WebkitBackgroundClip: "text",
               WebkitTextFillColor: "transparent",

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -36,7 +36,11 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage: "none",
-          border: "1px solid #334155",
+          // Glassy translucent surface so card edges blend with the gradient bg
+          backgroundColor: "rgba(30,41,59,0.55)",
+          border: "1px solid rgba(148,163,184,0.10)",
+          backdropFilter: "blur(10px)",
+          WebkitBackdropFilter: "blur(10px)",
         },
       },
     },


### PR DESCRIPTION
## Summary
Addresses the reported issues:
1. **Card borders not blending** → Paper cards now use a glassy translucent surface (`rgba(30,41,59,0.55)` + soft `rgba(148,163,184,0.1)` border + blur), so edges blend with the gradient background on mobile and desktop.
2. **Chat bot** → confirmed the `@copilotlive/react-sdk` prebuilt widget is correctly bundled (the earlier "not loading" was the deploy race serving stale/raw content). Verifying live after this deploy.
3. **"A bit about who I am"** → responsive, smaller heading on mobile with proper line-height/spacing so it's fully visible.
4. **"Kaily.ai" title** → chip moved to its own line; title is now a block heading with proper line-height + padding (no more gradient clipping / cramming next to the chip).
5. **Footer** → removed the "Built with React & Material UI" credit; now just `© <year> <name>`.

Plus: **rebalanced the laptop hero** — text + avatar were pushed to opposite edges with a void between; now centered together with a larger glowing avatar and a subtle rotating dotted ring.

## Test plan
- [ ] Cards blend with background (no hard borders), mobile + desktop
- [ ] Chat widget loads (bottom-right)
- [ ] Kaily.ai title fully visible on its own line
- [ ] About heading clean on mobile
- [ ] Hero balanced on laptop; footer credit gone

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfGjc4Z3Nq7adDWNBXA47r)_