### PR TITLE
Remove avatar dashed ring; make cards clearly visible on mobile

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -221,21 +221,6 @@ const Profile = () => {
 
           {/* Avatar side */}
           <Box sx={{ flexShrink: 0, position: "relative", display: "grid", placeItems: "center" }}>
-            {/* Decorative dotted ring */}
-            <Box
-              aria-hidden
-              component={motion.div}
-              animate={{ rotate: 360 }}
-              transition={{ duration: 40, repeat: Infinity, ease: "linear" }}
-              sx={{
-                position: "absolute",
-                width: { xs: 230, md: 320 },
-                height: { xs: 230, md: 320 },
-                borderRadius: "50%",
-                border: "1px dashed rgba(148,163,184,0.25)",
-                pointerEvents: "none",
-              }}
-            />
             <Box
               component={motion.div}
               animate={{ scale: [1, 1.04, 1] }}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -36,9 +36,9 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           backgroundImage: "none",
-          // Glassy translucent surface so card edges blend with the gradient bg
-          backgroundColor: "rgba(30,41,59,0.55)",
-          border: "1px solid rgba(148,163,184,0.10)",
+          // Opaque enough to read clearly, soft border so edges blend (no harsh line)
+          backgroundColor: "rgba(30,41,59,0.92)",
+          border: "1px solid rgba(148,163,184,0.12)",
           backdropFilter: "blur(10px)",
           WebkitBackdropFilter: "blur(10px)",
         },


### PR DESCRIPTION
## Summary
1. **Removed the dashed ring** around the hero avatar (looked weird). The avatar keeps its gradient ring + glow.
2. **Cards were too transparent** after the glass change (About card barely visible on mobile). Bumped the Paper background to `rgba(30,41,59,0.92)` so cards read clearly, while keeping the soft `rgba(148,163,184,0.12)` border so edges still blend (no harsh line).

## Test plan
- [ ] Hero avatar has no dashed circle
- [ ] About summary card is clearly visible on mobile with a subtle, non-harsh border

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfGjc4Z3Nq7adDWNBXA47r)_