### PR TITLE
Blend the Featured card border with its gradient

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -61,7 +61,7 @@ const FeaturedCard = ({ project }: { project: Project }) => {
           borderRadius: 4,
           mb: 3,
           p: { xs: 3, md: 4 },
-          border: "1px solid rgba(99,102,241,0.4)",
+          border: "1px solid rgba(148,163,184,0.12)",
           background:
             "linear-gradient(135deg, rgba(99,102,241,0.12), rgba(34,211,238,0.06))",
         }}


### PR DESCRIPTION
## Summary
The Featured "Kaily.ai" card had a gradient background but a distinct indigo border (`rgba(99,102,241,0.4)`) that clashed with it and looked like a weird hard line. Softened the border to the same neutral `rgba(148,163,184,0.12)` used by other cards, so it blends — while keeping the gradient background and glow accent for emphasis.

## Test plan
- [ ] Featured Kaily.ai card no longer shows a clashing colored border line

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfGjc4Z3Nq7adDWNBXA47r)_